### PR TITLE
Only show visible events on the home page.

### DIFF
--- a/client/routes/home/index.js
+++ b/client/routes/home/index.js
@@ -14,7 +14,7 @@ export default class Home extends Component {
 
   async componentWillMount() {
     const { events } = await (await fetch(
-      '/api/admin/events?type=full'
+      '/api/admin/events?type=full&visible=true'
     )).json();
     this.setState({ events });
   }

--- a/server/api/admin/events.js
+++ b/server/api/admin/events.js
@@ -41,7 +41,14 @@ async function handleGetEventsRequest(req, res, next) {
 
   if (req.query.type === 'full') {
     events = events.map(eventId => {
-      const { eventName } = config(eventId);
+      const { eventName, isVisible } = config(eventId);
+      return { eventId, eventName, isVisible };
+    });
+
+    if (req.query.visible === 'true') {
+      events = events.filter(({ isVisible }) => isVisible);
+    }
+    events = events.map(({ eventId, eventName }) => {
       return { eventId, eventName };
     });
   }


### PR DESCRIPTION
I was going to do this by returning the visibility status in the call to `/api/admin/events` and filtering in the client side. Eventually decided to do so by adding a query parameter and only returning visible events.