### PR TITLE
Handles no events in admin better.

### DIFF
--- a/client/components/panels/event-configurator/index.js
+++ b/client/components/panels/event-configurator/index.js
@@ -48,9 +48,9 @@ export default class EventConfigurator extends Component {
       onUpdateEventConfig,
       onCancelOrders,
     } = this.props;
-    const eventOptions = events.map(x => (
+    const eventOptions = events ? events.map(x => (
       <option selected={x === currentEventId}>{x}</option>
-    ));
+    )) : [];
     const selectEventOptions = (
       <div class={style.eventSelector}>
         <label for="eventPicker">Pick your event</label>
@@ -78,10 +78,8 @@ export default class EventConfigurator extends Component {
         </Button>
       </div>
     );
-    return (
+    const eventConfigurator = (
       <div>
-        <CreateEventForm onNewEvent={onCreateEvent} />
-        {events.length > 0 && selectEventOptions}
         <h5>Event Configuration</h5>
         {currentEventConfig ? (
           <Configurator
@@ -89,9 +87,16 @@ export default class EventConfigurator extends Component {
             update={onUpdateEventConfig}
           />
         ) : (
-          <Progress indeterminate />
+          <p>There are no events, please create one above.</p>
         )}
         {currentEventConfig && eventActionButtons}
+      </div>
+    )
+    return (
+      <div>
+        <CreateEventForm onNewEvent={onCreateEvent} />
+        {events && events.length > 0 && selectEventOptions}
+        {events ? eventConfigurator : (<Progress indeterminate />)}
       </div>
     );
   }

--- a/client/routes/admin/index.js
+++ b/client/routes/admin/index.js
@@ -12,7 +12,7 @@ export default class Orders extends Component {
   constructor(...args) {
     super(...args);
 
-    this.state.events = [];
+    this.state.events = undefined;
     this.state.config = undefined;
     this.state.eventConfig = undefined;
     this.configService = ConfigService.shared();
@@ -133,7 +133,7 @@ export default class Orders extends Component {
     if (this.eventId) {
       this.configService.changeEvent(this.eventId);
     } else {
-      this.setState({ eventConfig: {} });
+      this.setState({ eventConfig: undefined });
     }
   }
 


### PR DESCRIPTION
This handles the threeway state of events not yet loaded, no events and available events better in the admin. Previously, the loading bar would appear when there were no events, now there is a message to show there are no events yet.

Working on this also uncovered that when you delete the last event the event action buttons would hang around. They now disappear.