### PR TITLE
The PWA shouldn't restrict the orientation.

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Barista",
   "start_url": "/",
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#fff",
   "theme_color": "#F22F46",
   "icons": [


### PR DESCRIPTION
I have a tablet with a built in stand that sits the tablet in landscape mode. I was unable to use the homescreen version of the app because it insisted on portrait mode.